### PR TITLE
Remove suppressed rules because they were not enabled in the test configuration

### DIFF
--- a/src/main/java/com/parasoft/findings/utils/common/IStringConstants.java
+++ b/src/main/java/com/parasoft/findings/utils/common/IStringConstants.java
@@ -35,7 +35,7 @@ public interface IStringConstants {
     /**
      * The line feed (\n) character.
      */
-    String CHAR_LINEFEED = "\n"; //$NON-NLS-1$ // parasoft-suppress PORT.LNSP "constant value"
+    String CHAR_LINEFEED = "\n"; //$NON-NLS-1$
 
     /**
      * The empty string.

--- a/src/main/java/com/parasoft/findings/utils/common/logging/FindingsLogger.java
+++ b/src/main/java/com/parasoft/findings/utils/common/logging/FindingsLogger.java
@@ -72,7 +72,7 @@ public final class FindingsLogger {
         if (FACTORY != null) {
             try {
                 handler = FACTORY.getHandler(sName);
-            } catch (Throwable thr) { // parasoft-suppress SECURITY.UEHL.LGE "Reviewed" // parasoft-suppress OWASP2021.A5.NCE "This is intentionally designed to prevent exceptions from bubbling up and causing the program to terminate." // parasoft-suppress OWASP2021.A9.LGE "This is intentionally designed to prevent exceptions from bubbling up and causing the program to terminate. The current method is a static method and other non-static log methods cannot be called, so the log messages are not printed here."
+            } catch (Throwable thr) { // parasoft-suppress OWASP2021.A5.NCE "This is intentionally designed to prevent exceptions from bubbling up and causing the program to terminate." // parasoft-suppress OWASP2021.A9.LGE "This is intentionally designed to prevent exceptions from bubbling up and causing the program to terminate. The current method is a static method and other non-static log methods cannot be called, so the log messages are not printed here."
                 // error in factory - cannot obtain handler
             }
         }
@@ -307,7 +307,7 @@ public final class FindingsLogger {
     private void tryLog(Runnable logMethod) {
         try {
             logMethod.run();
-        } catch (Throwable thr) { // parasoft-suppress SECURITY.UEHL.LGE "Reviewed" // parasoft-suppress OWASP2021.A5.NCE "This is intentionally designed to prevent exceptions from bubbling up and causing the program to terminate."
+        } catch (Throwable thr) { // parasoft-suppress OWASP2021.A5.NCE "This is intentionally designed to prevent exceptions from bubbling up and causing the program to terminate."
             error(thr);
             // error in handler - logging failed
         }
@@ -383,7 +383,7 @@ public final class FindingsLogger {
         }
 
         StringWriter writer = new StringWriter();
-        throwable.printStackTrace(new PrintWriter(writer, true)); // parasoft-suppress MISC.ACPST "Required to prepare logging info."
+        throwable.printStackTrace(new PrintWriter(writer, true));
 
         StringReader reader = null;
         LineNumberReader lineReader = null;

--- a/src/main/java/com/parasoft/findings/utils/common/logging/Level.java
+++ b/src/main/java/com/parasoft/findings/utils/common/logging/Level.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 /**
  * This class introduces a new Findings levels like TIME, TRACE etc...
  */
-public final class Level // parasoft-suppress OWASP2021.A8.OROM "Using default serialization mechanism."
+public final class Level
         implements Serializable {
     /**
      * Automatically generated variable: serialVersionUID

--- a/src/main/java/com/parasoft/findings/utils/common/nls/MessageResourceBundle.java
+++ b/src/main/java/com/parasoft/findings/utils/common/nls/MessageResourceBundle.java
@@ -175,7 +175,7 @@ public final class MessageResourceBundle {
      * Class which sub-classes java.util.Properties and uses the #put method to
      * set field values rather than storing the values in the table.
      */
-    private static class MessagesProperties // parasoft-suppress OWASP2021.A8.OROM "Using default serialization mechanism."
+    private static class MessagesProperties
             extends MessageBundleProperties {
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/parasoft/findings/utils/common/util/FileUtil.java
+++ b/src/main/java/com/parasoft/findings/utils/common/util/FileUtil.java
@@ -94,7 +94,7 @@ public final class FileUtil {
      */
     public static void readFile(File file, List<String> lines)
             throws IOException {
-        BufferedReader reader = new BufferedReader(new FileReader(file)); // parasoft-suppress INTER.SEO "Want to use default encoding"
+        BufferedReader reader = new BufferedReader(new FileReader(file));
         try {
             String sLine = reader.readLine();
             while (sLine != null) {
@@ -250,7 +250,7 @@ public final class FileUtil {
             byte[] aBuffer = new byte[BUFFER_SIZE];
 
             int numOfBytes = 0;
-            while ((numOfBytes = bufferedIn.read(aBuffer)) != -1) { // parasoft-suppress OPT.CEL "reviewed"
+            while ((numOfBytes = bufferedIn.read(aBuffer)) != -1) {
                 bufferedOut.write(aBuffer, 0, numOfBytes);
             }
 
@@ -297,7 +297,7 @@ public final class FileUtil {
         }
         try {
             is.close();
-        } catch (IOException exc) { // parasoft-suppress SECURITY.UEHL.LGE "acceptable"
+        } catch (IOException exc) {
             Logger.getLogger().debug(exc.getMessage());
         }
     }
@@ -313,12 +313,12 @@ public final class FileUtil {
         }
         try {
             os.flush();
-        } catch (IOException exc) { // parasoft-suppress SECURITY.UEHL.LGE "acceptable"
+        } catch (IOException exc) {
             Logger.getLogger().debug(exc.getMessage());
         }
         try {
             os.close();
-        } catch (IOException exc) { // parasoft-suppress SECURITY.UEHL.LGE "acceptable"
+        } catch (IOException exc) {
             Logger.getLogger().debug(exc.getMessage());
         }
     }

--- a/src/main/java/com/parasoft/findings/utils/common/util/IOUtils.java
+++ b/src/main/java/com/parasoft/findings/utils/common/util/IOUtils.java
@@ -167,7 +167,7 @@ public final class IOUtils {
             byte[] aBuffer = new byte[bufferSize];
 
             int numOfBytes = 0;
-            while ((numOfBytes = bufferedSource.read(aBuffer)) != -1) { // parasoft-suppress OPT.CEL "reviewed"
+            while ((numOfBytes = bufferedSource.read(aBuffer)) != -1) {
                 bufferedDestination.write(aBuffer, 0, numOfBytes);
             }
 

--- a/src/main/java/com/parasoft/findings/utils/common/variables/StringSubstitutionEngine.java
+++ b/src/main/java/com/parasoft/findings/utils/common/variables/StringSubstitutionEngine.java
@@ -67,7 +67,7 @@ public class StringSubstitutionEngine {
         substitute(sExpression, bReportUndefinedVariables, bResolveVariables);
         List<Set<String>> resolvedVariableSets = new ArrayList<Set<String>>();
         while (_bSubstitutions) {
-            Set<String> resolved = substitute(_sbResultBuffer.toString(), bReportUndefinedVariables, true);  // parasoft-suppress OPT.LIOL "Revised"
+            Set<String> resolved = substitute(_sbResultBuffer.toString(), bReportUndefinedVariables, true);
 
             for (int i = resolvedVariableSets.size() - 1; i >= 0; i--) {
                 Set<String> prevSet = resolvedVariableSets.get(i);

--- a/src/main/java/com/parasoft/findings/utils/doc/remote/JSONException.java
+++ b/src/main/java/com/parasoft/findings/utils/doc/remote/JSONException.java
@@ -16,7 +16,7 @@
 
 package com.parasoft.findings.utils.doc.remote;
 
-public class JSONException extends RuntimeException { // parasoft-suppress OWASP2021.A8.OROM "Using default serialization mechanism."
+public class JSONException extends RuntimeException {
     private static final long serialVersionUID = 0L;
     private Throwable cause;
 

--- a/src/main/java/com/parasoft/findings/utils/doc/remote/ResponseWithContentException.java
+++ b/src/main/java/com/parasoft/findings/utils/doc/remote/ResponseWithContentException.java
@@ -24,7 +24,7 @@ import org.apache.http.client.HttpResponseException;
 /**
  * Signals a non 2xx HTTP response.
  */
-public final class ResponseWithContentException // parasoft-suppress OWASP2021.A8.OROM "Using default serialization mechanism."
+public final class ResponseWithContentException
         extends HttpResponseException {
 
     private static final long serialVersionUID = -419207194615475081L;

--- a/src/main/java/com/parasoft/findings/utils/results/location/LegacyResultLocationsReader.java
+++ b/src/main/java/com/parasoft/findings/utils/results/location/LegacyResultLocationsReader.java
@@ -68,7 +68,7 @@ public class LegacyResultLocationsReader extends DefaultHandler implements IResu
     }
 
     public Properties getStoredLocation(String loc) {
-        return _locations.get(loc); // parasoft-suppress BD.OPT.INEFMAP "Reviewed, not modifying public methods to obtain iterable elements."
+        return _locations.get(loc);
     }
 
     public ResultLocation getResultLocation(String loc, SourceRange sourceRange, boolean bAcceptModified)

--- a/src/main/java/com/parasoft/findings/utils/results/location/LocationsReader.java
+++ b/src/main/java/com/parasoft/findings/utils/results/location/LocationsReader.java
@@ -84,7 +84,7 @@ public class LocationsReader extends DefaultHandler {
     }
 
     public Properties getStoredLocation(String sLocRef) {
-        return _locations.get(sLocRef); // parasoft-suppress BD.OPT.INEFMAP "Reviewed, not modifying public methods to obtain iterable elements."
+        return _locations.get(sLocRef);
     }
 
     private static final String ILLEGAL_TAG_MESSAGE = "Tag with illegal name spotted:";  //$NON-NLS-1$

--- a/src/main/java/com/parasoft/findings/utils/results/violations/IFlowAnalysisPathElement.java
+++ b/src/main/java/com/parasoft/findings/utils/results/violations/IFlowAnalysisPathElement.java
@@ -52,10 +52,10 @@ public interface IFlowAnalysisPathElement
      * Below the line we have got method and interfaces that should be to get code compilable before fully re-factoring it.
      * There could be also methods that could be moved above the line if we assume that there are important.
      */
-    interface Type // parasoft-suppress JAVADOC.PJDC "Temporary api for internal purpose."
+    interface Type
     {
-        String getIdentifier(); // parasoft-suppress JAVADOC.PJDM "Temporary api for internal purpose."
+        String getIdentifier();
     }
 
-    Type getType(); // parasoft-suppress JAVADOC.PJDM "Temporary api for internal purpose."
+    Type getType();
 }

--- a/src/main/java/com/parasoft/findings/utils/results/xml/StaticXmlStorage.java
+++ b/src/main/java/com/parasoft/findings/utils/results/xml/StaticXmlStorage.java
@@ -36,7 +36,7 @@ public class StaticXmlStorage {
     }
 
     public IViolationsSAXReader getViolationsReader(ResultVersionsManager versionsManager, FileImportPreferences importPreferences) {
-        List<IViolationXmlStorage> storagesList = new ArrayList<IViolationXmlStorage>(); // parasoft-suppress CDD.DUPC "acceptable"
+        List<IViolationXmlStorage> storagesList = new ArrayList<IViolationXmlStorage>();
         List<String> tagsList = new ArrayList<String>();
         collectCompatibleStorages(versionsManager, tagsList, storagesList);
 

--- a/src/main/java/com/parasoft/findings/utils/rules/IRuleConstants.java
+++ b/src/main/java/com/parasoft/findings/utils/rules/IRuleConstants.java
@@ -29,7 +29,7 @@ public interface IRuleConstants
     String COLUMN_TAG = "column"; //$NON-NLS-1$
     String ROW_TAG = "row"; //$NON-NLS-1$
     String MSG_TAG = "msg"; //$NON-NLS-1$
-    String ID_ATTR = "id"; //$NON-NLS-1$  // parasoft-suppress CDD.DUPS "reviewed"
+    String ID_ATTR = "id"; //$NON-NLS-1$
     String NAME_ATTR = "name"; //$NON-NLS-1$
     String DESCRIPTION_ATTR = "description"; //$NON-NLS-1$
     String SEVERITY_ATTR = "severity"; //$NON-NLS-1$

--- a/src/main/java/com/parasoft/findings/utils/rules/RuleDescription.java
+++ b/src/main/java/com/parasoft/findings/utils/rules/RuleDescription.java
@@ -101,7 +101,7 @@ public class RuleDescription
 
     protected void addAttribute(String sName, String sValue)
     {
-        if (_attributes == null) { // parasoft-suppress TRS.ILI "Verified"
+        if (_attributes == null) {
             _attributes = new HashMap<String, String>();
         }
         _attributes.put(sName, sValue);

--- a/src/main/java/com/parasoft/findings/utils/rules/RuleDescriptionBody.java
+++ b/src/main/java/com/parasoft/findings/utils/rules/RuleDescriptionBody.java
@@ -67,7 +67,7 @@ public class RuleDescriptionBody
 
         public void addAttribute(String sName, String sValue)
         {
-            if (_attributes == null) { // parasoft-suppress TRS.ILI "Verified"
+            if (_attributes == null) {
                 _attributes = new HashMap<String, String>();
             }
             _attributes.put(sName, sValue);
@@ -75,7 +75,7 @@ public class RuleDescriptionBody
 
         public void addChild(BodyElement element)
         {
-            if (_children == null) { // parasoft-suppress TRS.ILI "Verified"
+            if (_children == null) {
                 _children = new ArrayList<BodyElement>();
             }
             _children.add(element);


### PR DESCRIPTION
The test configuration used in SOAVirt for the following rules is not enabled:
* [Not Enabled] OWASP2021.A8.OROM
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/OWASP2021.A8.OROM

* [Not Enabled] PORT.LNSP
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/PORT.LNSP

* [Not Enabled] INTER.SEO
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/INTER.SEO

* [Not Enabled] OPT.CEL
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/OPT.CEL

* [Not Enabled] SECURITY.UEHL.LGE
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/SECURITY.UEHL.LGE

* [Not Enabled] OPT.LIOL
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/OPT.LIOL

* [Not Enabled] BD.OPT.INEFMAP
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/BD.OPT.INEFMAP

* [Not Enabled] JAVADOC.PJDC
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/JAVADOC.PJDC

* [Not Enabled] JAVADOC.PJDM
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/JAVADOC.PJDM

* [Not Enabled] CDD.DUPC
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/CDD.DUPC

* [Not Enabled] TRS.ILI
https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/97/rule/TRS.ILI

* [Not Found] MISC.ACPST
Not Found

Solutions: Remove suppression information